### PR TITLE
Use $this->pollingOptions() Method for Dynamic Polling Options

### DIFF
--- a/src/Concerns/HasPolling.php
+++ b/src/Concerns/HasPolling.php
@@ -25,7 +25,7 @@ trait HasPolling
 
     protected function polling(): string
     {
-        if (! array_key_exists($this->polling, $this->pollingOptions)) {
+        if (! array_key_exists($this->polling, $this->pollingOptions())) {
             return '';
         }
 


### PR DESCRIPTION
This update allows dynamic assignment of polling options, such as language translations, rather than using hardcoded values, and ensures the correct polling options are referenced everywhere.

This change is particularly beneficial for applications that require multi-language support and more configurable options.

-----

Code snippet of the improvement and reasons why it's useful:

```php
protected function pollingOptions(): array
{
    return [
        '' => trans('language.variable.none'),
        '5s' => trans('language.variable.5s'),
        '10s' => trans('language.variable.10s'),
    ];
}
```

Unless we reference `$this->pollingOptions()` here, the polling will not work properly on LIvewireTables.