### PR TITLE
Utilize Laravel's Container for Dependency Resolution of models

### DIFF
--- a/src/Livewire/LivewireTable.php
+++ b/src/Livewire/LivewireTable.php
@@ -77,7 +77,7 @@ class LivewireTable extends Component
         /** @var Model $model */
         $model = $this->model;
 
-        return new $model;
+        return app($model);
     }
 
     /** @return Builder<Model> */


### PR DESCRIPTION
This pull request updates the `model` method to utilize Laravel's container for resolving model dependencies and instantiating objects, improving modularity and flexibility for app developers.

With this change, developers can easily swap models in their service providers as needed.

These changes have been made with the aim of maintaining backward compatibility and ensuring that there are no side effects or incompatibilities.

-----

Code snippet of the improvement and reasons why it's useful:

```php
namespace App;

use Illuminate\Support\ServiceProvider;

class AppServiceProvider extends ServiceProvider
{
    public function register()
    {
        $this->app->singleton(\Third\Party\Model::class, \App\Models\Custom::class);
    }
}
```

This update ensures we retrieve the model from service container, and that the resulted model is always the same, even if it's been overridden somewhere else.