### PR TITLE
fix: resolve issue with SelectColumn search behavior

### DIFF
--- a/src/Columns/Concerns/HasSearch.php
+++ b/src/Columns/Concerns/HasSearch.php
@@ -3,8 +3,9 @@
 namespace RamonRietdijk\LivewireTables\Columns\Concerns;
 
 use Closure;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use RamonRietdijk\LivewireTables\Columns\SelectColumn;
 
 trait HasSearch
 {
@@ -40,9 +41,15 @@ trait HasSearch
     /** @param  Builder<Model>  $builder */
     public function search(Builder $builder, mixed $search): void
     {
-        $this->qualifyQuery($builder, function (Builder $builder, string $column) use ($search): void {
-            $builder->where($column, 'LIKE', '%'.$search.'%');
-        });
+        if ($this instanceof SelectColumn) {
+            $this->qualifyQuery($builder, function (Builder $builder, string $column) use ($search): void {
+                $builder->where($column, $search);
+            });
+        } else {
+            $this->qualifyQuery($builder, function (Builder $builder, string $column) use ($search): void {
+                $builder->where($column, 'LIKE', '%'.$search.'%');
+            });
+        }
     }
 
     /** @param  Builder<Model>  $builder */


### PR DESCRIPTION
Modified the search method in the HasSearch trait to address an issue where the default 'LIKE' search behavior caused incorrect results for SelectColumn. Now, when dealing with SelectColumn, it uses an exact match for options during searching.