### PR TITLE
Do not overwrite user defined select

### DIFF
--- a/src/Concerns/HasSelect.php
+++ b/src/Concerns/HasSelect.php
@@ -10,7 +10,7 @@ trait HasSelect
     /** @param  Builder<Model>  $builder */
     protected function applySelect(Builder $builder): static
     {
-        $builder->select($builder->qualifyColumn('*'));
+        $builder->addSelect($builder->qualifyColumn('*'));
 
         return $this;
     }


### PR DESCRIPTION
Laravel Eloquent's `select` method will remove all previously set columns from the selection:
`src/Illuminate/Database/Query/Builder.php`

```php
    public function select($columns = ['*'])
    {
        $this->columns = [];
        $this->bindings['select'] = [];
```

This is an issue when you add a selection to the `query` method of a table. For example:
```php
    protected function query(): Builder
    {
        return parent::query()
            ->leftJoin('results', function (JoinClause $join): void {
                $join->on('items.id', '=', 'results.item_id')
                    ->whereRaw('results.id IN (SELECT MAX(id) FROM results GROUP BY item_id)');
            })
            ->select([
                'items.*',
                'results.value_1',
                'results.value_2',
                'results.value_3',
            ]);
    }
```

In this case `results.field_` will never be available because it is overwritten in the `HasSelect` concern.