### PR TITLE
Replace LIKE with whereLike

### DIFF
--- a/src/Columns/Concerns/HasSearch.php
+++ b/src/Columns/Concerns/HasSearch.php
@@ -46,7 +46,7 @@ trait HasSearch
     {
         $this->qualifyQuery($builder, function (Builder $builder, string $column) use ($search): void {
             if (is_string($search)) {
-                $builder->where($column, 'LIKE', '%'.$search.'%');
+                $builder->whereLike($column, '%'.$search.'%');
             }
         });
     }


### PR DESCRIPTION
https://laravel.com/framework/docs/13.x/queries#additional-where-clauses

This fixes case sensitivity when using postgres